### PR TITLE
PIL 10+ not supported

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ version: 2
 jobs:
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 218bd5aed7680244688dbf0f1398f5251ad243267eb19a6a7332668ac779a1cc
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - matplotlib-base
     - numpy
     - omegaconf >=2.1
-    - pillow >=2.9
+    - pillow >=2.9,<10
     - pyproj >=2.2
     - python >=3.7
     - pytorch >=1.7


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

PIL 10+ support is fixed in https://github.com/microsoft/torchgeo/pull/567 and will be included in the next release.

Torchmetrics 0.9+ support is fixed in https://github.com/microsoft/torchgeo/pull/555 and will be included in the next release. Accidentally pushed this directly to main without opening a PR so conda-forge was never updated: https://github.com/conda-forge/torchgeo-feedstock/commit/59f89bcc4fed872957528571a6a51d80590129e0.

Until the next release, we should pin these to use older versions.