### PR TITLE
Add entry_points

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,15 +10,17 @@ source:
   sha256: 38c930917ea341d05a7a611ff74c017f29482df7455d50e287ea79dec7d0a14b
 
 build:
-  number: 0
+  entry_points:
+    - torchgeo = torchgeo.main:main
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 1
 
 requirements:
   host:
-    - pip
     - python >=3.10
     - setuptools >=61
+    - pip
   run:
     - python >=3.10
     - einops >=0.3
@@ -43,6 +45,7 @@ requirements:
     # Needed by LightningCLI
     - jsonargparse >=4.18
     - typeshed-client >=2.1
+
 test:
   imports:
     - torchgeo
@@ -55,15 +58,12 @@ test:
     - torchgeo.transforms
   commands:
     - pip check
-    - python -m torchgeo --help
     - torchgeo --help
   requires:
     - pip
 
 about:
   home: https://github.com/microsoft/torchgeo
-  doc_url: https://torchgeo.readthedocs.io/
-  dev_url: https://github.com/microsoft/torchgeo
   license: MIT
   license_file: LICENSE
   summary: 'TorchGeo: datasets, samplers, transforms, and pre-trained models for geospatial data'
@@ -74,6 +74,8 @@ about:
 
     1. for machine learning experts to work with geospatial data, and
     2. for remote sensing experts to explore machine learning solutions.
+  dev_url: https://github.com/microsoft/torchgeo
+  doc_url: https://torchgeo.readthedocs.io/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
I don't think this actually matters, but I noticed that grayskull adds it for lightning-uq-box, so figured I would add it for torchgeo too.

Also reordered some sections to match the default generated by grayskull and the docs.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

